### PR TITLE
feet/integrate_ci_cd: Add workflow for CI/CD

### DIFF
--- a/.github/workflows/csv-node-build.yml
+++ b/.github/workflows/csv-node-build.yml
@@ -1,0 +1,23 @@
+name: csv-node-build
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build-project:
+    name: build-project
+    run-os: ubuntu-latest
+    steps:
+      - name: Setup in NodeJS
+        uses: actions/setup-node@master # For init environment with nodejs
+        with: 
+          node-version: 10.0.0
+      - name: Install dependencies
+        run: yarn install
+      - name: "Running all test and collect the coverage"
+        run: yarn test --coverage
+      - name: Collect coverage
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./__test__/coverage/Icov.info

--- a/.github/workflows/csv-node-deploy.yml
+++ b/.github/workflows/csv-node-deploy.yml
@@ -1,0 +1,25 @@
+name: csv-node-deploy
+on:
+  create:
+    tag:
+      - v*
+jobs:
+  npm-publish:
+    name: npm-publish
+    run-os: ubuntu-latest
+    steps:
+      - name: Checkuot on github repository
+        uses: actions/checkout@master # For checkout
+      - name: Setup in NodeJS
+        uses: actions/setup-node@master # For init environment with nodejs
+        with: 
+          node-version: 10.0.0
+      - name: Publish if version has been updated
+        uses: pascalgn/npm-publish-action # For deploy in npm
+        with:
+          tag_name: "%s"
+          tag_message: "%s"
+          commit_pattern: "^Release (\\S+)"
+        env: # Variables for npm publish
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Automatic
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }} # You need to set this in your repo settings


### PR DESCRIPTION
The CI/CD is important for library open-source and to facilitate
the process of deploy.

closes #1