### PR TITLE
fix/publish_action: Publish action is triggered always

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: build
 on:
   pull_request:
     branches:
-      - master
+      - development
   push:
     branches:
-      - master
+      - development
 jobs:
   build-project:
     name: build-project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: publish
 on:
-  create:
-    tag:
-      v*
+  push:
+    branch:
+      - master
 jobs:
   npm-publish:
     name: publish


### PR DESCRIPTION
The publish action is triggered when hava an push in master, now exists
an branch development that have the code base of devs, an branch stage for test
before will to production on branch master, now always an push on master the npm actions
is triggered.

closes #36