### PR TITLE
feat/set_default_values_to_empty_columns: Set default to empty colums

### DIFF
--- a/__test__/unit/csvWriter.spec.ts
+++ b/__test__/unit/csvWriter.spec.ts
@@ -8,12 +8,20 @@ interface Person {
   birthdate: Date
 }
 
+interface BasePerson {
+  name: string
+  age: string
+}
+
 describe('Stream', () => {
   test('It should be write an object like csv file', async () => {
     const file = path.resolve(__dirname, '..', 'tmp', 'file5.csv')
 
-    const writer = new CSVWriter(file, {
-      headers: ['name', 'age']
+    const writer = new CSVWriter<BasePerson>(file, {
+      headers: {
+        name: 'name',
+        age: 'age'
+      }
     })
     const data = [
       { name: 'David0', age: '18' },
@@ -31,11 +39,69 @@ describe('Stream', () => {
       .toEqual('name,age\nDavid0,18\nDavid1,18\nDavid2,18\nDavid3,18\nDavid4,18\n')
   })
 
+  test('It should be write an object like csv file and complete the empty row with "NULL"', async () => {
+    const file = path.resolve(__dirname, '..', 'tmp', 'file5.csv')
+
+    const writer = new CSVWriter<Partial<BasePerson>>(file, {
+      headers: {
+        name: 'name',
+        age: 'age'
+      }
+    })
+    const data = [
+      { name: 'David0', age: '18' },
+      { name: 'David1' },
+      { age: '18' },
+      { name: 'David3', age: '18' },
+      { name: 'David4' }
+    ]
+
+    await writer.write(data)
+
+    const fileData = (await fs.promises.readFile(file)).toString('utf-8')
+
+    expect(fileData)
+      .toEqual('name,age\nDavid0,18\nDavid1,NULL\nNULL,18\nDavid3,18\nDavid4,NULL\n')
+  })
+
+  test('It should be write an object like csv file and complete the empty row with default values', async () => {
+    const file = path.resolve(__dirname, '..', 'tmp', 'file5.csv')
+
+    const writer = new CSVWriter<Partial<BasePerson>>(file, {
+      headers: {
+        name: 'name',
+        age: 'age'
+      },
+      defaultValue: {
+        name: 'NONE',
+        age: '0'
+      }
+    })
+    const data = [
+      { name: 'David0', age: '18' },
+      { name: 'David1' },
+      { age: '18' },
+      { name: 'David3', age: '18' },
+      { name: 'David4' }
+    ]
+
+    await writer.write(data)
+
+    const fileData = (await fs.promises.readFile(file)).toString('utf-8')
+
+    expect(fileData)
+      .toEqual('name,age\nDavid0,18\nDavid1,0\nNONE,18\nDavid3,18\nDavid4,0\n')
+  })
+
   test('It should be write an object with format values like csv file', async () => {
     const file = path.resolve(__dirname, '..', 'tmp', 'file5.csv')
 
     const writer = new CSVWriter<Person>(file, {
-      headers: ['name', 'age', 'birthdate'],
+      headers: {
+        name: 'name',
+        age: 'age',
+        birthdate: 'birthdate'
+      },
       format: {
         birthdate: (birthdate) => birthdate.getMilliseconds().toString()
       }

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -27,9 +27,14 @@ export enum NextStrategy{
 }
 
 export interface CSVWriterOptions<T>{
-  headers: string[]
+  headers: {
+    [P in keyof T]: string
+  }
   delimiter?: string
   format?: Partial<{
     [P in keyof T]: (value: T[P]) => string
+  }>
+  defaultValue?: Partial<{
+    [P in keyof T]: string
   }>
 }


### PR DESCRIPTION
Exists objects that can not are with all keys, therefore is necessary provide
an form of the user set default values to empty colums, that can the 'NULL'
as default or an custom value.

closes #48